### PR TITLE
Remove manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: goreleaser
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
This line was blocking the automated release process (presumably unexpected behavior from GitHub, but still).
We want this to be automated, so removing.